### PR TITLE
[ChannelTabs] 2.5.9 Redesign

### DIFF
--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -1252,6 +1252,7 @@ module.exports = (() => {
 					"div",
 					{},
 					React.createElement(TabIcon, {iconUrl: props.iconUrl, currentStatus: props.currentStatus }),
+					React.createElement(TabName, {name: props.name}),
 					React.createElement(
 						"div",
 						{
@@ -1272,9 +1273,7 @@ module.exports = (() => {
 						   {className: "channelTabs-gridItemTR"},
 						   !(props.selected ? props.showActiveTabMentionBadges : props.showTabMentionBadges) ? null : !(props.selected ? props.showEmptyActiveTabBadges : props.showEmptyTabBadges) && (props.mentionCount === 0) ? null : React.createElement(TabMentionBadge, {viewMode: "alt", mentionCount: props.mentionCount})
 					   ),
-					   React.createElement("div", {className: "channelTabs-gridItemBL"})
-					   ),
-					React.createElement(TabName, {name: props.name})
+					   React.createElement("div", {className: "channelTabs-gridItemBL"}))
 				)
 			};
 
@@ -2340,6 +2339,9 @@ module.exports = (() => {
 							--channelTabs-tabStatusBorderThickness: 2px;
 							--channelTabs-favStatusBorderThickness: 2px;
 							--channelTabs-winButtonWidth: 84px;
+							--channelTabs-paddingTop: 8px;
+							--channelTabs-paddingBottom: 4px;
+							--channelTabs-containerSpacing: 3px;
 						}
 					`;
 
@@ -2373,7 +2375,6 @@ module.exports = (() => {
 					.platform-win .titleBar-1it3bQ {
 						position: absolute;
 						right: 0;
-						height: calc(var(--channelTabs-tabHeight) + 10px);
 						z-index: unset;
 						-webkit-app-region: unset;
 						padding: unset;
@@ -2387,7 +2388,7 @@ module.exports = (() => {
 					
 					.winButton-3UMjdg {
 						top: unset;
-						height: calc(var(--channelTabs-tabHeight) + 10px);
+						height: calc(var(--channelTabs-tabHeight) + var(--channelTabs-paddingTop) + var(--channelTabs-paddingBottom));
 						z-index: 9999;
 					}
 					
@@ -2410,16 +2411,29 @@ module.exports = (() => {
 					
 					.platform-osx #channelTabs-container>#channelTabs-settingsMenu+div,
 					.platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
-						padding: 7px 72px 3px 0;
+						padding-top: var(--channelTabs-paddingTop);
+						padding-left: 0;
+						padding-right: 72px;
 						margin-left: 72px;
 						-webkit-app-region: drag;
 					}
 					
 					html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div,
 					html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
-						padding: 7px 72px 3px 8px;
+						padding-top: var(--channelTabs-paddingTop);
+						padding-left: 8px;
+						padding-right: 72px;
 						margin-right: var(--channelTabs-winButtonWidth);
 						-webkit-app-region: drag;
+					}
+					
+					#channelTabs-container>#channelTabs-settingsMenu+div+.channelTabs-favContainer,
+					#channelTabs-container>:first-child:not(#channelTabs-settingsMenu)+.channelTabs-favContainer {
+						padding-top: var(--channelTabs-containerSpacing);
+					}
+
+					#channelTabs-settingsMenu~div:last-child {
+						padding-bottom: var(--channelTabs-paddingBottom);
 					}
 					
 					.platform-osx #channelTabs-container>#channelTabs-settingsMenu+div>*,
@@ -2437,7 +2451,6 @@ module.exports = (() => {
 					.channelTabs-tabContainer {
 						display: flex;
 						align-items: center;
-						padding: 0 8px 3px 8px;
 					}
 
 					.channelTabs-tab {
@@ -2491,7 +2504,7 @@ module.exports = (() => {
 						display: inline-block;
 						float: right;
 						width: 20px;
-						height: calc(var(--channelTabs-tabHeight) + 10px);
+						height: calc(var(--channelTabs-tabHeight) + var(--channelTabs-paddingTop) + var(--channelTabs-paddingBottom));
 						margin-right: var(--channelTabs-winButtonWidth);
 						z-index: 9999;
 					}
@@ -2518,8 +2531,9 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-tabName {
-						margin: 0 6px 0 0;
+						margin: 0 6px 1px 0;
 						font-size: 12px;
+						line-height: normal;
 						color: var(--interactive-normal);
 						overflow: hidden;
 						white-space: nowrap;
@@ -2574,6 +2588,7 @@ module.exports = (() => {
 						height: 14px;
 						font-size: 14px;
 						line-height: 12px;
+						font-family: Whitney,"Helvetica Neue",Helvetica,Arial,sans-serif;
 						right: 6px;
 						text-align: center;
 						border-radius: 50%;
@@ -2706,6 +2721,10 @@ module.exports = (() => {
 					.channelTabs-fav .channelTabs-noTyping {
 						display: none;
 					}
+					
+					.channelTabs-fav>div:nth-last-child(2) {
+						margin-right: 6px;
+					}
 
 					.channelTabs-favGroupBtn .channelTabs-noMention,
 					.channelTabs-favGroupBtn .channelTabs-noUnread {
@@ -2731,10 +2750,6 @@ module.exports = (() => {
 					.channelTabs-favGroupBtn .channelTabs-noTyping {
 						display: none;
 					}
-					
-					.channelTabs-fav>div:nth-last-child(2) {
-						margin-right: 6px;
-					}
 
 					/*
 					//#endregion
@@ -2747,7 +2762,7 @@ module.exports = (() => {
 					.channelTabs-favContainer {
 						display: flex;
 						align-items: center;
-						padding: 0 8px 3px 8px;
+						padding: 0 8px 0 8px;
 					}
 
 					.channelTabs-fav {
@@ -2771,8 +2786,9 @@ module.exports = (() => {
 					}
 
 					.channelTabs-favIcon ~ .channelTabs-favName {
-						margin: 0 6px 0 0;
+						margin: 0 6px 1px 0;
 						font-size: 12px;
+						line-height: normal;
 						color: var(--interactive-normal);
 						overflow: hidden;
 						white-space: nowrap;
@@ -2845,16 +2861,11 @@ module.exports = (() => {
 						z-index: 1001;
 						display: none;
 						position: absolute;
-						background-color: var(--background-tertiary);
-						border-radius: 4px;
 						min-width: max-content;
-						background: var(--background-floating);
+						background-color: var(--background-floating);
 						-webkit-box-shadow: var(--elevation-high);
 						box-shadow: var(--elevation-high);
-					}
-
-					.channelTabs-favGroup-content .channelTabs-fav {
-						display: block;
+						border-radius: 4px;
 					}
 
 					.channelTabs-favGroupShow {

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -49,18 +49,18 @@ module.exports = (() => {
 					twitter_username: "carter5467_99"
 				}
 			],
-			version: "2.5.8",
+			version: "2.5.9",
 			description: "Allows you to have multiple tabs and bookmark channels",
 			github: "https://github.com/l0c4lh057/BetterDiscordStuff/blob/master/Plugins/ChannelTabs/",
 			github_raw: "https://raw.githubusercontent.com/l0c4lh057/BetterDiscordStuff/master/Plugins/ChannelTabs/ChannelTabs.plugin.js"
 		},
 		changelog: [
 			{
-				"title": "Fixed",
-				"type": "fixed",
+				"title": "NEW LOOK",
+				"type": "added",
 				"items": [
-					"The plugin now works again",
-					"Context menus are still broken, but at least everything else should work again now"
+					"Tabs squish n' squash like a normal browser!",
+					"Looks a bit closer to a native look."
 				]
 			}
 		]

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -2470,7 +2470,7 @@ module.exports = (() => {
 						display: flex;
 						width: calc(100% - 14px);
 						align-items: center;
-						margin-right: unset;
+						margin-right: unset !important;
 					}
 					
 					.channelTabs-tab:not(.channelTabs-selected):hover {
@@ -2588,6 +2588,7 @@ module.exports = (() => {
 
 					.channelTabs-closeTab {
 						position: relative;
+						flex-shrink: 0;
 						width: 14px;
 						height: 14px;
 						font-size: 14px;

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -2436,7 +2436,7 @@ module.exports = (() => {
 						padding-top: var(--channelTabs-containerSpacing);
 					}
 
-					#channelTabs-settingsMenu~div:last-child {
+					#channelTabs-container>div:last-child {
 						padding-bottom: var(--channelTabs-paddingBottom);
 					}
 					

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -2318,7 +2318,6 @@ module.exports = (() => {
 					const CompactVariables = `
 						:root {	
 							--channelTabs-tabHeight: 22px;
-							--channelTabs-tabTextSize: 15px;
 							--channelTabs-favHeight: 22px;
 							--channelTabs-macHeight: initial;
 						}
@@ -2327,7 +2326,6 @@ module.exports = (() => {
 					const CozyVariables = `
 						:root {	
 							--channelTabs-tabHeight: 32px;
-							--channelTabs-tabTextSize: 18px;
 							--channelTabs-favHeight: 28px;
 							--channelTabs-macHeight: 41px;
 						}
@@ -2346,11 +2344,11 @@ module.exports = (() => {
 					`;
 
 					const PrivacyStyle = `
-						.channelTabs-favGroupBtn {
+						#app-mount .channelTabs-favGroupBtn {
 							color: transparent !important;
 						}
 
-						.channelTabs-tabName {
+						#app-mount .channelTabs-tabName {
 							color: transparent;
 							background-color: var(--interactive-normal);
 							opacity: 0.5;
@@ -2360,7 +2358,8 @@ module.exports = (() => {
 							background-color: var(--interactive-active);
 						}
 						
-						.channelTabs-favName {
+						#app-mount .channelTabs-favName {
+							color: transparent;
 							background-color: var(--interactive-normal);
 							opacity: 0.5;
 						}
@@ -2400,7 +2399,7 @@ module.exports = (() => {
 						margin-top: 0;
 					}
 					
-					.platform-osx .sidebar-1tnWFu {
+					html:not(.platform-win) .sidebar-1tnWFu {
 						border-radius: 8px 0 0;
 						overflow: hidden;
 					}
@@ -2408,23 +2407,28 @@ module.exports = (() => {
 					.macButtons-eIdy0e {
 						height: var(--channelTabs-macHeight);
 					}
-					
-					.platform-osx #channelTabs-container>#channelTabs-settingsMenu+div,
-					.platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
+
+					#channelTabs-container>#channelTabs-settingsMenu+div,
+					#channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
 						padding-top: var(--channelTabs-paddingTop);
-						padding-left: 0;
 						padding-right: 72px;
-						margin-left: 72px;
 						-webkit-app-region: drag;
 					}
 					
 					html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div,
 					html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
-						padding-top: var(--channelTabs-paddingTop);
 						padding-left: 8px;
-						padding-right: 72px;
+					}
+					
+					.platform-osx #channelTabs-container>#channelTabs-settingsMenu+div,
+					.platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
+						padding-left: 0;
+						margin-left: 72px;
+					}
+					
+					.platform-win #channelTabs-container>#channelTabs-settingsMenu+div,
+					.platform-win #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
 						margin-right: var(--channelTabs-winButtonWidth);
-						-webkit-app-region: drag;
 					}
 					
 					#channelTabs-container>#channelTabs-settingsMenu+div+.channelTabs-favContainer,
@@ -2436,8 +2440,8 @@ module.exports = (() => {
 						padding-bottom: var(--channelTabs-paddingBottom);
 					}
 					
-					.platform-osx #channelTabs-container>#channelTabs-settingsMenu+div>*,
-					.platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
+					html:not(.platform-win) #channelTabs-container>#channelTabs-settingsMenu+div>*,
+					html:not(.platform-win) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
 					html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div>*,
 					html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
 					.menu-1QACrS {
@@ -2495,7 +2499,7 @@ module.exports = (() => {
 					//#region Quick Settings
 					*/
 					
-					.platform-osx #channelTabs-settingsMenu {
+					html:not(.platform-win) #channelTabs-settingsMenu {
 						margin-right: 0;
 					}
 
@@ -2559,19 +2563,19 @@ module.exports = (() => {
 					}
 
 					.channelTabs-tabIcon.channelTabs-onlineIcon {
-						border: var(--channelTabs-tabStatusBorderThickness) solid rgb(67, 181, 129);
+						border: var(--channelTabs-tabStatusBorderThickness) solid hsl(139, calc(var(--saturation-factor, 1) * 47.3%), 43.9%);
 					}
 
 					.channelTabs-tabIcon.channelTabs-idleIcon {
-						border: var(--channelTabs-tabStatusBorderThickness) solid rgb(250, 166, 26);
+						border: var(--channelTabs-tabStatusBorderThickness) solid hsl(38, calc(var(--saturation-factor, 1) * 95.7%), 54.1%);
 					}
 
 					.channelTabs-tabIcon.channelTabs-doNotDisturbIcon {
-						border: var(--channelTabs-tabStatusBorderThickness) solid rgb(216, 68, 68);
+						border: var(--channelTabs-tabStatusBorderThickness) solid hsl(359, calc(var(--saturation-factor, 1) * 82.6%), 59.4%);
 					}
 
 					.channelTabs-tabIcon.channelTabs-offlineIcon {
-						border: var(--channelTabs-tabStatusBorderThickness) solid rgb(111, 121, 134);
+						border: var(--channelTabs-tabStatusBorderThickness) solid hsl(214, calc(var(--saturation-factor, 1) * 9.9%), 50.4%);
 					}
 
 					/*
@@ -2651,7 +2655,6 @@ module.exports = (() => {
 						text-align: center;
 						color: #fff;
 					}
-					
 
 					.channelTabs-mentionBadge {
 						background-color: rgb(240, 71, 71);
@@ -2678,7 +2681,6 @@ module.exports = (() => {
 						float: right;
 					}
 
-
 					.channelTabs-tab .channelTabs-mentionBadge,
 					.channelTabs-tab .channelTabs-unreadBadge,
 					.channelTabs-tab .channelTabs-typingBadge {
@@ -2690,7 +2692,6 @@ module.exports = (() => {
 						right: calc(0px - var(--channelTabs-tabStatusBorderThickness));
 						bottom: calc(0px - var(--channelTabs-tabStatusBorderThickness));
 					}
-					
 
 					.channelTabs-tab .channelTabs-noMention,
 					.channelTabs-tab .channelTabs-noUnread {
@@ -2711,6 +2712,7 @@ module.exports = (() => {
 						vertical-align: bottom;
 						float: right;
 						margin-left: 2px;
+						margin-right: 6px;
 					}
 				
 					.channelTabs-fav .channelTabs-noMention,
@@ -2802,27 +2804,19 @@ module.exports = (() => {
 					}
 
 					.channelTabs-favIcon.channelTabs-onlineIcon {
-						border: var(--channelTabs-favStatusBorderThickness) solid rgb(67, 181, 129);
-						left: var(--channelTabs-favStatusBorderThickness);
-						top: var(--channelTabs-favStatusBorderThickness);
+						border: var(--channelTabs-favStatusBorderThickness) solid hsl(139, calc(var(--saturation-factor, 1) * 47.3%), 43.9%);
 					}
 
 					.channelTabs-favIcon.channelTabs-idleIcon {
-						border: var(--channelTabs-favStatusBorderThickness) solid rgb(250, 166, 26);
-						left: var(--channelTabs-favStatusBorderThickness);
-						top: var(--channelTabs-favStatusBorderThickness);
+						border: var(--channelTabs-favStatusBorderThickness) solid hsl(38, calc(var(--saturation-factor, 1) * 95.7%), 54.1%);
 					}
 
 					.channelTabs-favIcon.channelTabs-doNotDisturbIcon {
-						border: var(--channelTabs-favStatusBorderThickness) solid rgb(216, 68, 68);
-						left: var(--channelTabs-favStatusBorderThickness);
-						top: var(--channelTabs-favStatusBorderThickness);
+						border: var(--channelTabs-favStatusBorderThickness) solid hsl(359, calc(var(--saturation-factor, 1) * 82.6%), 59.4%);
 					}
 
 					.channelTabs-favIcon.channelTabs-offlineIcon {
-						border: var(--channelTabs-favStatusBorderThickness) solid rgb(111, 121, 134);
-						left: var(--channelTabs-favStatusBorderThickness);
-						top: var(--channelTabs-favStatusBorderThickness);
+						border: var(--channelTabs-favStatusBorderThickness) solid hsl(214, calc(var(--saturation-factor, 1) * 9.9%), 50.4%);
 					}
 
 					/*

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -2318,41 +2318,49 @@ module.exports = (() => {
 				{
 					const CompactVariables = `
 						:root {	
-							--channelTabs-tabHeight: 20px;
+							--channelTabs-tabHeight: 22px;
 							--channelTabs-tabTextSize: 15px;
+                            --channelTabs-favHeight: 22px;
+                            --channelTabs-macHeight: initial;
 						}
 					`;
 
 					const CozyVariables = `
 						:root {	
-							--channelTabs-tabHeight: 40px;
+							--channelTabs-tabHeight: 32px;
 							--channelTabs-tabTextSize: 18px;
+                            --channelTabs-favHeight: 28px;
+                            --channelTabs-macHeight: 41px;
 						}
 					`;
 
 					const ConstantVariables = `
 						:root {	
-							--channelTabs-tabWidth: 220px;
-							--channelTabs-favHeight: 20px;
+							--channelTabs-tabWidth: 224px;
 							--channelTabs-tabStatusBorderThickness: 2px;
 							--channelTabs-favStatusBorderThickness: 2px;
+                            --channelTabs-winButtonWidth: 84px;
 						}
 					`;
 
 					const PrivacyStyle = `
-						.channelTabs-favGroupBtn  {
-							color: transparent;
-							text-shadow: 0 0 7px var(--interactive-normal);
+						.channelTabs-favGroupBtn {
+							color: transparent !important;
 						}
 
-						.channelTabs-tabName  {
-							color: transparent;
-							text-shadow: 0 0 7px var(--interactive-normal);
+						.channelTabs-tabName {
+                            color: transparent;
+							background-color: var(--interactive-normal);
+                            opacity: 0.5;
 						}
+
+                        .channelTabs-selected .channelTabs-tabName {
+                            background-color: var(--interactive-active);
+                        }
 						
-						.channelTabs-fav  {
-							color: transparent;
-							text-shadow: 0 0 7px var(--interactive-normal);
+						.channelTabs-favName {
+							background-color: var(--interactive-normal);
+                            opacity: 0.5;
 						}
 					`;
 		
@@ -2362,40 +2370,99 @@ module.exports = (() => {
 					//#region Tab Base/Container
 					*/
 
-					.channelTabs-tab {
-						display: inline-block;
-						margin: 2px 0;
-						margin-left: 4px;
-						font-size: calc(var(--channelTabs-tabTextSize));
-						width: var(--channelTabs-tabWidth);
-						position: relative;
-						background: var(--background-secondary);
-						border: none;
-						padding: 6px 6px 6px 6px;
-						border-radius: 4px;
-						color: var(--interactive-normal);
-						height: var(--channelTabs-tabHeight);
-					}
+                    .platform-win .titleBar-1it3bQ {
+                        position: absolute;
+                        right: 0;
+                        height: calc(var(--channelTabs-tabHeight) + 10px);
+                        z-index: unset;
+                        -webkit-app-region: unset;
+                        padding: unset;
+                        background: unset;
+                        box-shadow: unset;
+                    }
 
-					#channelTabs-container {
+                    .platform-win .withFrame-2dL45i {
+                        margin-top: unset;
+                    }
+
+                    .winButton-3UMjdg {
+                        top: unset;
+                        height: calc(var(--channelTabs-tabHeight) + 10px);
+                        z-index: 9999;
+                    }
+
+                    .platform-win .wordmark-2u86JB {
+                        display: none;
+                    }
+
+                    .platform-osx .wrapper-1_HaEi {
+                        margin-top: 0;
+                    }
+
+                    .platform-osx .sidebar-1tnWFu {
+                        border-radius: 8px 0 0;
+                        overflow: hidden;
+                    }
+
+                    .macButtons-eIdy0e {
+                        height: var(--channelTabs-macHeight);
+                    }
+
+                    .platform-osx #channelTabs-container>#channelTabs-settingsMenu+div,
+                    .platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
+                        padding: 7px 72px 3px 0;
+                        margin-left: 72px;
+                        -webkit-app-region: drag;
+                    }
+
+                    html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div,
+                    html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
+                        padding: 7px 72px 3px 8px;
+                        margin-right: var(--channelTabs-winButtonWidth);
+                        -webkit-app-region: drag;
+                    }
+
+                    .platform-osx #channelTabs-container>#channelTabs-settingsMenu+div>*,
+                    .platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
+                    html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div>*,
+                    html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
+                    .menu-1QACrS {
+                        -webkit-app-region: no-drag;
+                    }
+
+                    #channelTabs-container {
 						z-index: 1000;
 					}
 
-					.channelTabs-tabContainer {
-						min-height: calc(var(--channelTabs-tabHeight) + 16px);
-						background: rgb(var(--background-tertiary));
-						position: relative;
-					}
-					.channelTabs-tab:not(.channelTabs-selected):hover {
-						background: var(--background-modifier-active);
-						cursor: pointer;
-						color: var(--interactive-hover);
+                    .channelTabs-tabContainer {
+                        display: flex;
+                        align-items: center;
+                        padding: 0 8px 3px 8px;
+                    }
+
+					.channelTabs-tab {
+						display: flex;
+						align-items: center;
+                        min-width: 0;
+                        border-radius: 4px;
+                        height: var(--channelTabs-tabHeight);
+                        flex: 0 1 var(--channelTabs-tabWidth);
 					}
 
-					.channelTabs-tab.channelTabs-selected {
-						background: var(--background-modifier-selected);
-						color: var(--interactive-active);
-					}
+                    .channelTabs-tab>div:first-child {
+                        display: flex;
+                        width: calc(100% - 14px);
+                        align-items: center;
+                        margin-right: unset;
+                    }
+
+                    .channelTabs-tab:not(.channelTabs-selected):hover {
+                        background: var(--background-modifier-hover);
+                    }
+
+                    .channelTabs-tab.channelTabs-selected {
+                        background: var(--background-modifier-selected);
+                    }
 
 					.channelTabs-tab.channelTabs-unread:not(.channelTabs-selected),
 					.channelTabs-tab.channelTabs-unread:not(.channelTabs-selected),
@@ -2415,15 +2482,18 @@ module.exports = (() => {
 					//#region Quick Settings
 					*/
 
+                    .platform-osx #channelTabs-settingsMenu {
+                        margin-right: 0;
+                    }
+
 					#channelTabs-settingsMenu {
-						z-index: 1000;
-						height: 40px;
-						position: relative;
+                        position: relative;
 						display: inline-block;
-						background: rgb(var(--background-tertiary));
-						width: 40px;
-						float: right;
-						border-radius: 0% 0% 0% 0%;
+                        float: right;
+                        width: 20px;
+                        height: calc(var(--channelTabs-tabHeight) + 10px);
+                        margin-right: var(--channelTabs-winButtonWidth);
+                        z-index: 9999;
 					}
 
 					#channelTabs-settingsMenu:hover {
@@ -2448,19 +2518,17 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-tabName {
-						width: calc(var(--channelTabs-tabWidth) - 18px);
-						display: inline-block;
-						position: absolute;
-						overflow: hidden;
-						white-space: nowrap;
-						text-overflow: ellipsis;
-						height: 50%;
-						margin: auto;
-						top: 0; left: 5px; bottom: 0; right: 0;
-					}
-					.channelTabs-tabName:only-child {
-						width: calc(var(--channelTabs-tabWidth) - 2px);
-					}
+                        margin: 0 6px 0 0;
+                        font-size: 12px;
+                        color: var(--interactive-normal);
+                        overflow: hidden;
+                        white-space: nowrap;
+                        text-overflow: ellipsis;
+                    }
+
+                    .channelTabs-selected .channelTabs-tabName {
+                        color: var(--interactive-active);
+                    }
 
 					/*
 					//#endregion
@@ -2471,15 +2539,10 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-tabIcon {
-						height: calc(var(--channelTabs-tabHeight) - var(--channelTabs-tabStatusBorderThickness));
-						display: inline-block;
-						border-radius: 100%;
-						position: absolute;
-					}
-					.channelTabs-tabIcon ~ .channelTabs-tabName {
-						margin-left: calc(var(--channelTabs-tabHeight) + 7px);
-						width: calc(var(--channelTabs-tabWidth) - var(--channelTabs-tabHeight) - 6px);
-					}
+                        border-radius: 50%;
+                        height: 20px;
+                        margin: 0 6px;
+                    }
 
 					.channelTabs-tabIcon.channelTabs-onlineIcon {
 						border: var(--channelTabs-tabStatusBorderThickness) solid rgb(67, 181, 129);
@@ -2497,10 +2560,6 @@ module.exports = (() => {
 						border: var(--channelTabs-tabStatusBorderThickness) solid rgb(111, 121, 134);
 					}
 
-					.channelTabs-tabIcon.channelTabs-noneIcon {
-						border: var(--channelTabs-tabStatusBorderThickness) solid rgb(50, 52, 57);
-					}
-
 					/*
 					//#endregion
 					*/
@@ -2510,50 +2569,37 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-closeTab {
-						display: inline-block;
-						position: absolute;
-						right: 0px;
-						top: 0px;
-						width: 14px;
-						height: 14px;
-						border-radius: 0px 5px 0px 5px;
-						text-align: center;
-						line-height: 14px;
-						font-size: 14px;
-						background: var(--interactive-muted);
-						color: var(--background-secondary-alt);
-						cursor: pointer;
-					}
-					.channelTabs-tab.channelTabs-selected .channelTabs-closeTab {
-						background: var(--interactive-normal);
-					}
-					.channelTabs-tab:not(.channelTabs-selected):hover .channelTabs-closeTab:hover {
-						background: hsl(359, calc(var(--saturation-factor, 1)*82.6%), 59.4%);
-						color: white;
-					}
-					.channelTabs-tab.channelTabs-selected .channelTabs-closeTab:hover {
-						background: hsl(359, calc(var(--saturation-factor, 1)*82.6%), 59.4%);
-						color: white;
-					}
+                        position: relative;
+                        width: 14px;
+                        height: 14px;
+                        font-size: 14px;
+                        line-height: 12px;
+                        right: 6px;
+                        text-align: center;
+                        border-radius: 50%;
+                        color: var(--interactive-normal);
+                        cursor: pointer;
+                    }
 					
 					.channelTabs-newTab {
-						display: inline-block;
-						margin-left: 5px;
-						padding: 3px;
-						border-radius: 50%;
-						width: 15px;
-						height: 15px;
-						text-align: center;
-						background: var(--interactive-muted);
-						font-weight: 600;
-						cursor: pointer;
-						color: var(--background-secondary-alt);
-						position: absolute;
-						bottom: calc(var(--channelTabs-tabHeight) / 2 - 2px);
+                        flex-shrink: 0;
+                        width: 18px;
+                        height: 18px;
+                        margin: 0 6px 0 6px;
+                        font-size: 18px;
+                        font-weight: 700;
+                        font-family: Whitney,"Helvetica Neue",Helvetica,Arial,sans-serif;
+                        text-align: center;
+                        border-radius: 50%;
+                        cursor: pointer;
+                        color: var(--interactive-normal);
 					}
-					.channelTabs-newTab:hover {
-						background: var(--interactive-normal);
-					}
+
+                    .channelTabs-closeTab:hover,
+                    .channelTabs-newTab:hover {
+                        background: var(--background-modifier-selected);
+                        color: var(--interactive-hover);
+                    }
 
 					/*
 					//#endregion
@@ -2564,10 +2610,9 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-mentionBadge,
-					.channelTabs-unreadBadge  {
+					.channelTabs-unreadBadge {
 						border-radius: 8px;
-						padding-left: 4px;
-						padding-right: 4px;
+						padding: 0 4px;
 						min-width: 8px;
 						width: fit-content;
 						height: 16px;
@@ -2605,17 +2650,17 @@ module.exports = (() => {
 					}
 
 					.channelTabs-classicBadgeAlignment {
-						margin-right: 4px !important;
+						margin-right: 4px;
 						display: inline-block;
-						float: right !important;
+						float: right;
 					}
 
 					.channelTabs-badgeAlignLeft {
-						float: left !important;
+						float: left;
 					}
 
 					.channelTabs-badgeAlignRight {
-						float: right !important;
+						float: right;
 					}
 
 
@@ -2642,14 +2687,14 @@ module.exports = (() => {
 					.channelTabs-fav .channelTabs-unreadBadge {
 						display: inline-block;
 						vertical-align: bottom;
-						float: right !important;
+						float: right;
 						margin-left: 2px;
 					}
 
 					.channelTabs-fav .channelTabs-typingBadge {
 						display: inline-flex;
 						vertical-align: bottom;
-						float: right !important;
+						float: right;
 						margin-left: 2px;
 					}
 				
@@ -2671,7 +2716,7 @@ module.exports = (() => {
 					.channelTabs-favGroupBtn .channelTabs-typingBadge {
 						display: inline-flex;
 						vertical-align: bottom;
-						float: right !important;
+						float: right;
 						margin-left: 2px;
 					}
 
@@ -2679,7 +2724,7 @@ module.exports = (() => {
 					.channelTabs-favGroupBtn .channelTabs-unreadBadge {
 						display: inline-block;
 						vertical-align: bottom;
-						float: right !important;
+						float: right;
 						margin-left: 2px;
 					}
 
@@ -2687,6 +2732,9 @@ module.exports = (() => {
 						display: none;
 					}
 					
+                    .channelTabs-fav>div:nth-last-child(2) {
+                        margin-right: 6px;
+                    }
 
 					/*
 					//#endregion
@@ -2697,38 +2745,45 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-favContainer {
-						min-height: calc(var(--channelTabs-favHeight) + 10px);
-						position: relative;
+						display: flex;
+                        align-items: center;
+                        padding: 0 8px 3px 8px;
 					}
 
 					.channelTabs-fav {
-						position: relative;
-						display: inline-block;
-						font-size: calc(var(--channelTabs-favHeight) - 2px);
-						color: var(--interactive-normal);
-						padding: 6px;
-						margin-left: 5px;
-						border-radius: 4px;
+						display: flex;
+						align-items: center;
+                        min-width: 0;
+                        border-radius: 4px;
+                        height: var(--channelTabs-favHeight);
+                        flex: 0 1 1;
+                        max-width: var(--channelTabs-tabWidth);
 					}
+
 					.channelTabs-fav:hover {
-						background-color: var(--background-secondary-alt);
-					}
+                        background: var(--background-modifier-hover);
+                    }
+
 					.channelTabs-favIcon {
-						height: var(--channelTabs-favHeight);
-						display: inline-block;
-						border-radius: 100%;
-						position: absolute;
+						border-radius: 50%;
+                        height: 20px;
+                        margin: 0 6px;
 					}
+
 					.channelTabs-favIcon ~ .channelTabs-favName {
-						margin-left: calc(var(--channelTabs-favHeight) + 3px);
+						margin: 0 6px 0 0;
+                        font-size: 12px;
+                        color: var(--interactive-normal);
+                        overflow: hidden;
+                        white-space: nowrap;
+                        text-overflow: ellipsis;
 					}
 					
 					.channelTabs-noFavNotice {
-						color: var(--text-muted);
-						font-size: calc(var(--channelTabs-favHeight) - 5px);
-						position: absolute;
-						padding: 5px;
-					}
+                        color: var(--text-muted);
+                        font-size: 14px;
+                        padding: 2px;
+                    }
 
 					.channelTabs-favIcon.channelTabs-onlineIcon {
 						border: var(--channelTabs-favStatusBorderThickness) solid rgb(67, 181, 129);
@@ -2754,12 +2809,6 @@ module.exports = (() => {
 						top: var(--channelTabs-favStatusBorderThickness);
 					}
 
-					.channelTabs-favIcon.channelTabs-noneIcon {
-						border: var(--channelTabs-favStatusBorderThickness) solid rgb(50, 52, 57);
-						left: var(--channelTabs-favStatusBorderThickness);
-						top: var(--channelTabs-favStatusBorderThickness);
-					}
-
 					/*
 					//#endregion 
 					*/
@@ -2769,22 +2818,27 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-favGroupBtn {
-						display: inline-block;
-						font-size: calc(var(--channelTabs-favHeight) - 2px);
-						color: var(--interactive-normal);
-						background-color: var(--background-tertiary);
-						padding: 6px;
-						margin-left: 5px;
-						border-radius: 4px;
+						display: flex;
+						align-items: center;
+                        min-width: 0;
+                        border-radius: 4px;
+                        height: var(--channelTabs-favHeight);
+                        flex: 0 1 1;
+                        max-width: var(--channelTabs-tabWidth);
+                        padding: 0 6px;
+                        font-size: 12px;
+                        color: var(--interactive-normal);
+                        overflow: hidden;
+                        white-space: nowrap;
+                        text-overflow: ellipsis;
 					}
 
+                    .channelTabs-favGroupBtn>:first-child {
+                        margin-left: 6px;
+                    }
+
 					.channelTabs-favGroup:hover .channelTabs-favGroupBtn {
-						background-color: var(--background-secondary-alt);
-					}
-					
-					.channelTabs-favGroup {
-						position: relative;
-						display: inline-block;
+						background: var(--background-modifier-hover);
 					}
 		
 					.channelTabs-favGroup-content {
@@ -2806,72 +2860,10 @@ module.exports = (() => {
 					.channelTabs-favGroupShow {
 						display:block;
 					}
-		
-					  
-
-					  
-
 
 					/*
 					//#endregion
 					*/
-
-					/*
-					//#region Tab Grid
-					*/
-
-					.channelTabs-gridContainer {
-						margin-left: 7px;
-						width: var(--channelTabs-tabHeight) !important;
-						height: var(--channelTabs-tabHeight) !important;
-						left: 0px;
-						//background-color: red;
-						display: inline-grid;
-						grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-						position: absolute;
-					}
-
-					.channelTabs-gridItemTL {
-						grid-column: 1 / 1;
-						grid-row: 1 / 1;
-						//background-color: blue;
-					}
-					.channelTabs-gridItemTR {
-						grid-column: 2 / 2;
-						grid-row: 1 / 1;
-						//background-color: green;
-					}
-					.channelTabs-gridItemBL {
-						grid-column: 1 / 1;
-						grid-row: 2 / 2;
-						//background-color: green;
-					}
-					.channelTabs-gridItemBR {
-						grid-column: 2 / 2;
-						grid-row: 2 / 2;
-						//background-color: blue;
-					}
-
-					/*
-					//#endregion 
-					*/
-					
-					/* MAC FIX */
-					/* first tab/fav in the tab/fav-bar, depends whether tab bar is enabled */
-					.${DiscordClassModules.Titlebar.typeMacOS.replace(/ /g, ".")} ~ div #channelTabs-container > :first-child > :first-child {
-						margin-left: 72px;
-					}
-					/* remove top margin of guild list, not necessary anymore */
-					.platform-osx .wrapper-1Rf91z {
-						margin-top: 0;
-					}
-					.platform-osx .scroller-2TZvBN {
-						padding-top: 12px;
-					}
-					/* make first bar of channeltabs draggable */
-					.${DiscordClassModules.Titlebar.typeMacOS.replace(/ /g, ".")} ~ div #channelTabs-container > :first-child {
-						-webkit-app-region: drag;
-					}
 					`;
 
 					if (this.settings.compactStyle === true) PluginUtilities.addStyle("channelTabs-style-compact", CompactVariables);

--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -2320,8 +2320,8 @@ module.exports = (() => {
 						:root {	
 							--channelTabs-tabHeight: 22px;
 							--channelTabs-tabTextSize: 15px;
-                            --channelTabs-favHeight: 22px;
-                            --channelTabs-macHeight: initial;
+							--channelTabs-favHeight: 22px;
+							--channelTabs-macHeight: initial;
 						}
 					`;
 
@@ -2329,8 +2329,8 @@ module.exports = (() => {
 						:root {	
 							--channelTabs-tabHeight: 32px;
 							--channelTabs-tabTextSize: 18px;
-                            --channelTabs-favHeight: 28px;
-                            --channelTabs-macHeight: 41px;
+							--channelTabs-favHeight: 28px;
+							--channelTabs-macHeight: 41px;
 						}
 					`;
 
@@ -2339,7 +2339,7 @@ module.exports = (() => {
 							--channelTabs-tabWidth: 224px;
 							--channelTabs-tabStatusBorderThickness: 2px;
 							--channelTabs-favStatusBorderThickness: 2px;
-                            --channelTabs-winButtonWidth: 84px;
+							--channelTabs-winButtonWidth: 84px;
 						}
 					`;
 
@@ -2349,18 +2349,18 @@ module.exports = (() => {
 						}
 
 						.channelTabs-tabName {
-                            color: transparent;
+							color: transparent;
 							background-color: var(--interactive-normal);
-                            opacity: 0.5;
+							opacity: 0.5;
 						}
-
-                        .channelTabs-selected .channelTabs-tabName {
-                            background-color: var(--interactive-active);
-                        }
+						
+						.channelTabs-selected .channelTabs-tabName {
+							background-color: var(--interactive-active);
+						}
 						
 						.channelTabs-favName {
 							background-color: var(--interactive-normal);
-                            opacity: 0.5;
+							opacity: 0.5;
 						}
 					`;
 		
@@ -2370,99 +2370,99 @@ module.exports = (() => {
 					//#region Tab Base/Container
 					*/
 
-                    .platform-win .titleBar-1it3bQ {
-                        position: absolute;
-                        right: 0;
-                        height: calc(var(--channelTabs-tabHeight) + 10px);
-                        z-index: unset;
-                        -webkit-app-region: unset;
-                        padding: unset;
-                        background: unset;
-                        box-shadow: unset;
-                    }
-
-                    .platform-win .withFrame-2dL45i {
-                        margin-top: unset;
-                    }
-
-                    .winButton-3UMjdg {
-                        top: unset;
-                        height: calc(var(--channelTabs-tabHeight) + 10px);
-                        z-index: 9999;
-                    }
-
-                    .platform-win .wordmark-2u86JB {
-                        display: none;
-                    }
-
-                    .platform-osx .wrapper-1_HaEi {
-                        margin-top: 0;
-                    }
-
-                    .platform-osx .sidebar-1tnWFu {
-                        border-radius: 8px 0 0;
-                        overflow: hidden;
-                    }
-
-                    .macButtons-eIdy0e {
-                        height: var(--channelTabs-macHeight);
-                    }
-
-                    .platform-osx #channelTabs-container>#channelTabs-settingsMenu+div,
-                    .platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
-                        padding: 7px 72px 3px 0;
-                        margin-left: 72px;
-                        -webkit-app-region: drag;
-                    }
-
-                    html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div,
-                    html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
-                        padding: 7px 72px 3px 8px;
-                        margin-right: var(--channelTabs-winButtonWidth);
-                        -webkit-app-region: drag;
-                    }
-
-                    .platform-osx #channelTabs-container>#channelTabs-settingsMenu+div>*,
-                    .platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
-                    html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div>*,
-                    html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
-                    .menu-1QACrS {
-                        -webkit-app-region: no-drag;
-                    }
-
-                    #channelTabs-container {
+					.platform-win .titleBar-1it3bQ {
+						position: absolute;
+						right: 0;
+						height: calc(var(--channelTabs-tabHeight) + 10px);
+						z-index: unset;
+						-webkit-app-region: unset;
+						padding: unset;
+						background: unset;
+						box-shadow: unset;
+					}
+					
+					.platform-win .withFrame-2dL45i {
+						margin-top: unset;
+					}
+					
+					.winButton-3UMjdg {
+						top: unset;
+						height: calc(var(--channelTabs-tabHeight) + 10px);
+						z-index: 9999;
+					}
+					
+					.platform-win .wordmark-2u86JB {
+						display: none;
+					}
+					
+					.platform-osx .wrapper-1_HaEi {
+						margin-top: 0;
+					}
+					
+					.platform-osx .sidebar-1tnWFu {
+						border-radius: 8px 0 0;
+						overflow: hidden;
+					}
+					
+					.macButtons-eIdy0e {
+						height: var(--channelTabs-macHeight);
+					}
+					
+					.platform-osx #channelTabs-container>#channelTabs-settingsMenu+div,
+					.platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
+						padding: 7px 72px 3px 0;
+						margin-left: 72px;
+						-webkit-app-region: drag;
+					}
+					
+					html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div,
+					html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu) {
+						padding: 7px 72px 3px 8px;
+						margin-right: var(--channelTabs-winButtonWidth);
+						-webkit-app-region: drag;
+					}
+					
+					.platform-osx #channelTabs-container>#channelTabs-settingsMenu+div>*,
+					.platform-osx #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
+					html:not(.platform-osx) #channelTabs-container>#channelTabs-settingsMenu+div>*,
+					html:not(.platform-osx) #channelTabs-container>:first-child:not(#channelTabs-settingsMenu)>*,
+					.menu-1QACrS {
+						-webkit-app-region: no-drag;
+					}
+					
+					#channelTabs-container {
 						z-index: 1000;
 					}
-
-                    .channelTabs-tabContainer {
-                        display: flex;
-                        align-items: center;
-                        padding: 0 8px 3px 8px;
-                    }
+					
+					.channelTabs-tabContainer {
+						display: flex;
+						align-items: center;
+						padding: 0 8px 3px 8px;
+					}
 
 					.channelTabs-tab {
 						display: flex;
 						align-items: center;
-                        min-width: 0;
-                        border-radius: 4px;
-                        height: var(--channelTabs-tabHeight);
-                        flex: 0 1 var(--channelTabs-tabWidth);
+						min-width: 0;
+						border-radius: 4px;
+						height: var(--channelTabs-tabHeight);
+						flex: 0 1 var(--channelTabs-tabWidth);
 					}
-
-                    .channelTabs-tab>div:first-child {
-                        display: flex;
-                        width: calc(100% - 14px);
-                        align-items: center;
-                        margin-right: unset;
-                    }
-
-                    .channelTabs-tab:not(.channelTabs-selected):hover {
-                        background: var(--background-modifier-hover);
-                    }
-
-                    .channelTabs-tab.channelTabs-selected {
-                        background: var(--background-modifier-selected);
-                    }
+					
+					.channelTabs-tab>div:first-child {
+						display: flex;
+						width: calc(100% - 14px);
+						align-items: center;
+						margin-right: unset;
+					}
+					
+					.channelTabs-tab:not(.channelTabs-selected):hover {
+						background: var(--background-modifier-hover);
+					}
+					
+					.channelTabs-tab.channelTabs-selected {
+						background: var(--background-modifier-selected);
+					}
 
 					.channelTabs-tab.channelTabs-unread:not(.channelTabs-selected),
 					.channelTabs-tab.channelTabs-unread:not(.channelTabs-selected),
@@ -2481,19 +2481,19 @@ module.exports = (() => {
 					/*
 					//#region Quick Settings
 					*/
-
-                    .platform-osx #channelTabs-settingsMenu {
-                        margin-right: 0;
-                    }
+					
+					.platform-osx #channelTabs-settingsMenu {
+						margin-right: 0;
+					}
 
 					#channelTabs-settingsMenu {
-                        position: relative;
+						position: relative;
 						display: inline-block;
-                        float: right;
-                        width: 20px;
-                        height: calc(var(--channelTabs-tabHeight) + 10px);
-                        margin-right: var(--channelTabs-winButtonWidth);
-                        z-index: 9999;
+						float: right;
+						width: 20px;
+						height: calc(var(--channelTabs-tabHeight) + 10px);
+						margin-right: var(--channelTabs-winButtonWidth);
+						z-index: 9999;
 					}
 
 					#channelTabs-settingsMenu:hover {
@@ -2518,17 +2518,17 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-tabName {
-                        margin: 0 6px 0 0;
-                        font-size: 12px;
-                        color: var(--interactive-normal);
-                        overflow: hidden;
-                        white-space: nowrap;
-                        text-overflow: ellipsis;
-                    }
-
-                    .channelTabs-selected .channelTabs-tabName {
-                        color: var(--interactive-active);
-                    }
+						margin: 0 6px 0 0;
+						font-size: 12px;
+						color: var(--interactive-normal);
+						overflow: hidden;
+						white-space: nowrap;
+						text-overflow: ellipsis;
+					}
+					
+					.channelTabs-selected .channelTabs-tabName {
+						color: var(--interactive-active);
+					}
 
 					/*
 					//#endregion
@@ -2539,10 +2539,10 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-tabIcon {
-                        border-radius: 50%;
-                        height: 20px;
-                        margin: 0 6px;
-                    }
+						border-radius: 50%;
+						height: 20px;
+						margin: 0 6px;
+					}
 
 					.channelTabs-tabIcon.channelTabs-onlineIcon {
 						border: var(--channelTabs-tabStatusBorderThickness) solid rgb(67, 181, 129);
@@ -2569,37 +2569,37 @@ module.exports = (() => {
 					*/
 
 					.channelTabs-closeTab {
-                        position: relative;
-                        width: 14px;
-                        height: 14px;
-                        font-size: 14px;
-                        line-height: 12px;
-                        right: 6px;
-                        text-align: center;
-                        border-radius: 50%;
-                        color: var(--interactive-normal);
-                        cursor: pointer;
-                    }
+						position: relative;
+						width: 14px;
+						height: 14px;
+						font-size: 14px;
+						line-height: 12px;
+						right: 6px;
+						text-align: center;
+						border-radius: 50%;
+						color: var(--interactive-normal);
+						cursor: pointer;
+					}
 					
 					.channelTabs-newTab {
-                        flex-shrink: 0;
-                        width: 18px;
-                        height: 18px;
-                        margin: 0 6px 0 6px;
-                        font-size: 18px;
-                        font-weight: 700;
-                        font-family: Whitney,"Helvetica Neue",Helvetica,Arial,sans-serif;
-                        text-align: center;
-                        border-radius: 50%;
-                        cursor: pointer;
-                        color: var(--interactive-normal);
+						flex-shrink: 0;
+						width: 18px;
+						height: 18px;
+						margin: 0 6px 0 6px;
+						font-size: 18px;
+						font-weight: 700;
+						font-family: Whitney,"Helvetica Neue",Helvetica,Arial,sans-serif;
+						text-align: center;
+						border-radius: 50%;
+						cursor: pointer;
+						color: var(--interactive-normal);
 					}
-
-                    .channelTabs-closeTab:hover,
-                    .channelTabs-newTab:hover {
-                        background: var(--background-modifier-selected);
-                        color: var(--interactive-hover);
-                    }
+					
+					.channelTabs-closeTab:hover,
+					.channelTabs-newTab:hover {
+						background: var(--background-modifier-selected);
+						color: var(--interactive-hover);
+					}
 
 					/*
 					//#endregion
@@ -2732,9 +2732,9 @@ module.exports = (() => {
 						display: none;
 					}
 					
-                    .channelTabs-fav>div:nth-last-child(2) {
-                        margin-right: 6px;
-                    }
+					.channelTabs-fav>div:nth-last-child(2) {
+						margin-right: 6px;
+					}
 
 					/*
 					//#endregion
@@ -2746,44 +2746,44 @@ module.exports = (() => {
 
 					.channelTabs-favContainer {
 						display: flex;
-                        align-items: center;
-                        padding: 0 8px 3px 8px;
+						align-items: center;
+						padding: 0 8px 3px 8px;
 					}
 
 					.channelTabs-fav {
 						display: flex;
 						align-items: center;
-                        min-width: 0;
-                        border-radius: 4px;
-                        height: var(--channelTabs-favHeight);
-                        flex: 0 1 1;
-                        max-width: var(--channelTabs-tabWidth);
+						min-width: 0;
+						border-radius: 4px;
+						height: var(--channelTabs-favHeight);
+						flex: 0 1 1;
+						max-width: var(--channelTabs-tabWidth);
 					}
 
 					.channelTabs-fav:hover {
-                        background: var(--background-modifier-hover);
-                    }
+						background: var(--background-modifier-hover);
+					}
 
 					.channelTabs-favIcon {
 						border-radius: 50%;
-                        height: 20px;
-                        margin: 0 6px;
+						height: 20px;
+						margin: 0 6px;
 					}
 
 					.channelTabs-favIcon ~ .channelTabs-favName {
 						margin: 0 6px 0 0;
-                        font-size: 12px;
-                        color: var(--interactive-normal);
-                        overflow: hidden;
-                        white-space: nowrap;
-                        text-overflow: ellipsis;
+						font-size: 12px;
+						color: var(--interactive-normal);
+						overflow: hidden;
+						white-space: nowrap;
+						text-overflow: ellipsis;
 					}
 					
 					.channelTabs-noFavNotice {
-                        color: var(--text-muted);
-                        font-size: 14px;
-                        padding: 2px;
-                    }
+						color: var(--text-muted);
+						font-size: 14px;
+						padding: 2px;
+					}
 
 					.channelTabs-favIcon.channelTabs-onlineIcon {
 						border: var(--channelTabs-favStatusBorderThickness) solid rgb(67, 181, 129);
@@ -2820,22 +2820,22 @@ module.exports = (() => {
 					.channelTabs-favGroupBtn {
 						display: flex;
 						align-items: center;
-                        min-width: 0;
-                        border-radius: 4px;
-                        height: var(--channelTabs-favHeight);
-                        flex: 0 1 1;
-                        max-width: var(--channelTabs-tabWidth);
-                        padding: 0 6px;
-                        font-size: 12px;
-                        color: var(--interactive-normal);
-                        overflow: hidden;
-                        white-space: nowrap;
-                        text-overflow: ellipsis;
+						min-width: 0;
+						border-radius: 4px;
+						height: var(--channelTabs-favHeight);
+						flex: 0 1 1;
+						max-width: var(--channelTabs-tabWidth);
+						padding: 0 6px;
+						font-size: 12px;
+						color: var(--interactive-normal);
+						overflow: hidden;
+						white-space: nowrap;
+						text-overflow: ellipsis;
 					}
-
-                    .channelTabs-favGroupBtn>:first-child {
-                        margin-left: 6px;
-                    }
+					
+					.channelTabs-favGroupBtn>:first-child {
+						margin-left: 6px;
+					}
 
 					.channelTabs-favGroup:hover .channelTabs-favGroupBtn {
 						background: var(--background-modifier-hover);


### PR DESCRIPTION
Overhaul of the current 2.5.8 styling.
* Tabs now behave like a browser instead of being in a grid
* New styling looks more consistent with Discord design
* Mac styling and settings icon are fixed as standard (~~Though I don't think ChannelTabs works on mac atm~~ Didn’t seem to work for me on macOS)

![gif](https://user-images.githubusercontent.com/90428263/160265100-3d4853f7-9faf-4d79-a430-a98ac6a15832.gif)

The `--channelTabs-winButtonWidth` variable is for themes that have wider/thinner windows buttons.
The commits might need to be squashed to not clutter the history.