### PR TITLE
fix:Discord crash when trying to use account switch feature

### DIFF
--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -1098,7 +1098,7 @@ module.exports = (() => {
 			const getChannelTypingUsers = (channel_id) => 
 			{
 				const channel = ChannelStore.getChannel(channel_id);
-				const selfId = UserStore.getCurrentUser().id;
+				const selfId = UserStore.getCurrentUser()?.id;
 				if (channel)
 				{	
 					const userIds = Object.keys(UserTypingStore.getTypingUsers(channel_id)).filter(uId => (uId !== selfId));
@@ -1111,7 +1111,7 @@ module.exports = (() => {
 			const isChannelTyping = (channel_id) => 
 			{
 				const channel = ChannelStore.getChannel(channel_id);
-				const selfId = UserStore.getCurrentUser().id;
+				const selfId = UserStore.getCurrentUser()?.id;
 				if (channel)
 				{	
 					const userIds = Object.keys(UserTypingStore.getTypingUsers(channel_id)).filter(uId => (uId !== selfId));


### PR DESCRIPTION
Fixed crash described on #115 , credits to [@ActuallyTheSun](https://github.com/ActuallyTheSun) for pointing the problem.