### PR TITLE
[Channel Tabs] Add margin-right on Channel Tabs

### DIFF
--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -2753,6 +2753,7 @@ module.exports = (() => {
 						min-width: var(--channelTabs-tabWidthMin);
 						flex: 1 1 var(--channelTabs-tabWidthMin);
 						margin-bottom: 3px;
+						margin-right: 3px;
 					}
 					
 					.channelTabs-tab>div:first-child {


### PR DESCRIPTION
It just looks nicer, that's all.

Without: 
![image](https://user-images.githubusercontent.com/84212701/181865961-063c8ee8-65a1-49ad-af35-713f3cc67c86.png)

With: 
![image](https://user-images.githubusercontent.com/84212701/181865972-999a9cb6-89d9-4654-a264-62d30b0f1ee8.png)
