### PR TITLE
Fix crash when no tab is selected in ChannelTabs.onSwitch

### DIFF
--- a/Plugins/ChannelTabs/ChannelTabs.plugin.js
+++ b/Plugins/ChannelTabs/ChannelTabs.plugin.js
@@ -3375,6 +3375,8 @@ module.exports = (() => {
 							tabs: TopBarRef.current.state.tabs.map(tab => {
 								if(tab.selected){
 									const channelId = SelectedChannelStore.getChannelId();
+									const selectedIndex = this.settings.tabs.findIndex(tab2 => tab2.selected);
+									const minimized = selectedIndex !== -1 ? this.settings.tabs[selectedIndex].minimized : false;
 									return {
 										name: getCurrentName(),
 										url: location.pathname,
@@ -3382,13 +3384,14 @@ module.exports = (() => {
 										currentStatus: getCurrentUserStatus(location.pathname),
 										iconUrl: getCurrentIconUrl(location.pathname),
 										channelId: channelId,
-										minimized: this.settings.tabs[this.settings.tabs.findIndex(tab=>tab.selected)].minimized
+										minimized: minimized
 									};
 								}else{
 									return Object.assign({}, tab);
 								}
 							})
 						}, this.saveSettings);
+					}
 					}else if(!this.settings.reopenLastChannel){
 						const channelId = SelectedChannelStore.getChannelId();
 						this.settings.tabs[this.settings.tabs.findIndex(tab=>tab.selected)] = {
@@ -3398,7 +3401,10 @@ module.exports = (() => {
 							currentStatus: getCurrentUserStatus(location.pathname),
 							iconUrl: getCurrentIconUrl(location.pathname),
 							channelId: channelId,
-							minimized: this.settings.tabs[this.settings.tabs.findIndex(tab=>tab.selected)].minimized
+							minimized: (() => {
+							  const index = this.settings.tabs.findIndex((tab) => tab.selected);
+							  return index !== -1 ? this.settings.tabs[index].minimized : false;
+							})(),
 						};
 					}
 				}


### PR DESCRIPTION
This patch fixes a startup crash caused by `this.settings.tabs.findIndex(...)` returning -1 when no tab is selected. 

Accessing `.minimized` on an undefined tab caused: TypeError: Cannot read properties of undefined (reading 'minimized')

We now check if the index is valid before accessing `.minimized`, and default to `false` if not.

This fixes:
sentry.395064ce93b61e02.js:14 [PluginManager] ChannelTabs v2.7.5 could not be started. TypeError: Cannot read properties of undefined (reading 'minimized')